### PR TITLE
Improve npm module loading

### DIFF
--- a/jsgtk_modules/jsgtk/node_modules.js
+++ b/jsgtk_modules/jsgtk/node_modules.js
@@ -40,13 +40,19 @@
           fd = GFile.new_for_path(path + DIR_SEPARATOR + 'package.json');
           if (fd.query_exists(null)) {
             let content = JSON.parse(trim.call(fd.load_contents(null)[1]));
+            if (content.main == null) content.main = 'index.js';
             fd = GFile.new_for_path(path + DIR_SEPARATOR + content.main);
             if (fd.query_exists(null)) return fd;
           } else {
+            // TODO does npm guarantee a package.json
             fd = GFile.new_for_path(path + DIR_SEPARATOR + 'main.js');
             if (fd.query_exists(null)) return fd;
           }
       }
+    } else {
+        // cases such as require('my-lib/src/component')
+        let fd = GFile.new_for_path(path + '.js');
+        if (fd.query_exists(null)) return fd;
     }
     return null;
   }


### PR DESCRIPTION
This makes react load successfully.

Although, loading something as large as react can take multiple seconds:
```js
var start = new Date().getTime();
var r = require('react');
var end = new Date().getTime();
console.log(`loaded react, took ${end-start}ms`);
```