### PR TITLE
Add support for CJS

### DIFF
--- a/jsgtk
+++ b/jsgtk
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-Function=Function//; for a in "$@"; do if [ "$a" = "-d" ] || [ "$a" = "--debug" ]; then export GTK_DEBUG=interactive; fi; done; if [ "$GTK_DEBUG" != "interactive" ]; then export GJS_DISABLE_EXTRA_WARNINGS=1; fi; exec gjs "$0" "$@" && exit
+Function=Function//; for a in "$@"; do if [ "$a" = "-d" ] || [ "$a" = "--debug" ]; then export GTK_DEBUG=interactive; fi; done; if [ "$GTK_DEBUG" != "interactive" ]; then export GJS_DISABLE_EXTRA_WARNINGS=1; fi; if which gjs >/dev/null; then exec gjs "$0" "$@"; else exec cjs "$0" "$@"; fi; exit
 
 /* jshint esversion: 6, strict: true, node: true */
 /* global imports */


### PR DESCRIPTION
This adds support for CJS, the Cinnamon fork of GJS by adding an extra
check in the first bash line of the jsgtk file that will execute cjs
instead if gjs is not in the PATH. The tests and examples are working
with CJS.