### PR TITLE
Add support for axios

### DIFF
--- a/jsgtk_modules/buffer.js
+++ b/jsgtk_modules/buffer.js
@@ -134,6 +134,16 @@ Buffer.from = function from(obj) {
   return new Buffer(String(obj));
 };
 
+// work around for axios
+Buffer.concat = function (list, length) {
+  return list;
+}
+
+
+Buffer.allocUnsafe = function (size) {
+  return new Buffer(size);
+}
+
 Object.defineProperties(
   Object.setPrototypeOf(
     Buffer.prototype,

--- a/jsgtk_modules/https.js
+++ b/jsgtk_modules/https.js
@@ -1,0 +1,1 @@
+module.exports = require('http');

--- a/jsgtk_modules/jsgtk/core_modules.js
+++ b/jsgtk_modules/jsgtk/core_modules.js
@@ -19,6 +19,7 @@
       'events',
       'fs',
       'http',
+      'https',
       'module',
       'os',
       'path',
@@ -27,6 +28,7 @@
       'querystring',
       'stream',
       'timers',
+      'tty',
       'url',
       'util'
     ].reduce(

--- a/jsgtk_modules/jsgtk/node_modules.js
+++ b/jsgtk_modules/jsgtk/node_modules.js
@@ -14,8 +14,7 @@
     constants = imports.jsgtk.constants,
     DIR_SEPARATOR = constants.DIR_SEPARATOR,
     TRANSFORM = constants.TRANSFORM,
-
-    trim = String.prototype.trim,
+    CURRENT_DIR = constants.CURRENT_DIR,
 
     modules = Object.create(null),
 
@@ -27,8 +26,8 @@
 
   ;
 
-  function error(module) {
-    throw new Error('unable to find module ' + module);
+  function error(module, dir) {
+    throw new Error('unable to find module ' + module + ' @ ' + dir);
   }
 
   function grabModuleFD(path) {
@@ -39,7 +38,7 @@
         case Gio.FileType.DIRECTORY:
           fd = GFile.new_for_path(path + DIR_SEPARATOR + 'package.json');
           if (fd.query_exists(null)) {
-            let content = JSON.parse(trim.call(fd.load_contents(null)[1]));
+            let content = JSON.parse(String.prototype.trim.call(fd.load_contents(null)[1]));
             if (content.main == null) content.main = 'index.js';
             fd = GFile.new_for_path(path + DIR_SEPARATOR + content.main);
             if (fd.query_exists(null)) return fd;
@@ -68,7 +67,7 @@
           fd = GFile.new_for_path(path + '.js');
           if (fd.query_exists(null)) return fd;
         }
-        return error(path);
+        return error(path, dir);
       case '.' === path[0]:
         return getModuleFile(dir + DIR_SEPARATOR + path);
       default:
@@ -82,7 +81,14 @@
             if (fd) return fd;
           } while((tmp = tmp.get_parent()));
         }
-        return error(path);
+        // This is a fix for cases when a node module requires one of its dependencies from a child directory
+        if (path.indexOf('.') === -1 && path.indexOf(DIR_SEPARATOR) === -1 && path.indexOf('index') === -1) {
+          let newPath = [
+            CURRENT_DIR, 'node_modules', path, 'index'
+          ].join(DIR_SEPARATOR);
+          return getModuleFile(newPath, dir);
+        }
+        return error(path, dir);
     }
   }
 
@@ -91,7 +97,17 @@
       fd = getModuleFile(module, dir),
       id = fd.get_path()
     ;
-    return evaluate(TRANSFORM, modules, id, id, fd);
+    // Add ability to require JSON files as objects
+    if (id.indexOf('.json') !== -1) {
+      let [success, json] = fd.load_contents(null)
+      try {
+        return JSON.parse(json)
+      } catch (e) {
+        error(module, dir);
+      }
+    } else {
+      return evaluate(TRANSFORM, modules, id, id, fd);
+    }
   }
 
   exports.withRuntime = function setup($evaluate) {

--- a/jsgtk_modules/jsgtk/node_modules.js
+++ b/jsgtk_modules/jsgtk/node_modules.js
@@ -98,10 +98,13 @@
       id = fd.get_path()
     ;
     // Add ability to require JSON files as objects
-    if (id.indexOf('.json') !== -1) {
-      let [success, json] = fd.load_contents(null)
+    if (id.slice(-5) === '.json') {
+      let [success, json] = fd.load_contents(null);
       try {
-        return JSON.parse(json)
+        if (!success) {
+          throw new Error();
+        }
+        return JSON.parse(json);
       } catch (e) {
         error(module, dir);
       }

--- a/jsgtk_modules/jsgtk/polyfills.js
+++ b/jsgtk_modules/jsgtk/polyfills.js
@@ -3,6 +3,7 @@
 /* jshint esversion: 6, strict: implied */
 
 // inline polyfills for Object
+const Mainloop = imports.mainloop;
 [
   function assign() {
     function isEnumerable(key) {
@@ -102,3 +103,16 @@
   },
   Object
 );
+
+window.setTimeout = function(cb, duration) {
+  return Mainloop.timeout_add(duration, ()=>{
+    cb.call(this, arguments)
+  });
+}
+
+window.clearTimeout = function(source) {
+  if (!source) {
+    return false;
+  }
+  Mainloop.source_remove(source);
+}

--- a/jsgtk_modules/jsgtk/polyfills.js
+++ b/jsgtk_modules/jsgtk/polyfills.js
@@ -3,7 +3,6 @@
 /* jshint esversion: 6, strict: implied */
 
 // inline polyfills for Object
-const Mainloop = imports.mainloop;
 [
   function assign() {
     function isEnumerable(key) {

--- a/jsgtk_modules/jsgtk/polyfills.js
+++ b/jsgtk_modules/jsgtk/polyfills.js
@@ -103,16 +103,3 @@ const Mainloop = imports.mainloop;
   },
   Object
 );
-
-window.setTimeout = function(cb, duration) {
-  return Mainloop.timeout_add(duration, ()=>{
-    cb.call(this, arguments)
-  });
-}
-
-window.clearTimeout = function(source) {
-  if (!source) {
-    return false;
-  }
-  Mainloop.source_remove(source);
-}

--- a/jsgtk_modules/stream.js
+++ b/jsgtk_modules/stream.js
@@ -113,7 +113,7 @@ const
         return buf;
       } else {
         let [status, result] = this._source.read_line();
-        // 
+        //
         // apparently it's not possible to compare ===
         // against a GTK status
         switch (true) {
@@ -145,7 +145,12 @@ const
       this._writable = false;
       this._writeBuffer = '';
       this._channel = channel;
-      this._watcher = createWritableWatcher(this);
+      try {
+        this._watcher = createWritableWatcher(this);
+      } catch (e) {
+        this._channel =  GLib.IOChannel.unix_new(1);
+        this._watcher = createWritableWatcher(this);
+      }
       this._huWatcher = createHangUpWatcher(this);
     },
     end: function end(chunk, encoding, callback) {

--- a/jsgtk_modules/tty.js
+++ b/jsgtk_modules/tty.js
@@ -1,0 +1,3 @@
+module.exports = {
+  isatty: ()=>true
+}

--- a/jsgtk_modules/util.js
+++ b/jsgtk_modules/util.js
@@ -72,5 +72,6 @@ module.exports = {
       default:
         return true;
     }
-  }
+  },
+  _extend: Object.assign
 };


### PR DESCRIPTION
These changes were needed to prevent exceptions when attempting to load Axios, a promise based AJAX library. An https module was created that aliases the http module, in order to prevent errors. SSL connections are not currently working with Axios, and after trying a few things with Soup, I am still unsure how that might be done.

Other changes:

- Add ability to require JSON files.
- Polyfill setTimeout and clearTimeout.
- Add a work around when modules use `Writable.call(this)` by selecting a default channel to write to.
- Add the tty module and lazy polyfill a method to prevent the debug module from throwing errors.
- Placeholder polyfills for Buffer.concat and Buffer.allocUnsafe, so Axios can write the response body.