### PR TITLE
Refactor node module loading, and check circular dependencies

### DIFF
--- a/jsgtk
+++ b/jsgtk
@@ -128,6 +128,7 @@ Function=Function//; for a in "$@"; do if [ "$a" = "-d" ] || [ "$a" = "--debug" 
         return requireWithPath(module, CURRENT_DIR);
       }},
       loadedModules: {value: []},
+      redundantModules: {writable: true, value: 0}
     }
   );
 

--- a/jsgtk
+++ b/jsgtk
@@ -126,7 +126,8 @@ Function=Function//; for a in "$@"; do if [ "$a" = "-d" ] || [ "$a" = "--debug" 
       // access to modules even internally
       require: {value: function require(module) {
         return requireWithPath(module, CURRENT_DIR);
-      }}
+      }},
+      loadedModules: {value: []},
     }
   );
 

--- a/jsgtk_modules/jsgtk/core_modules.js
+++ b/jsgtk_modules/jsgtk/core_modules.js
@@ -30,7 +30,8 @@
       'timers',
       'tty',
       'url',
-      'util'
+      'util',
+      'zlib'
     ].reduce(
       (core, id) => Object.defineProperty(core, id, {
         configurable: true,

--- a/jsgtk_modules/jsgtk/node_modules.js
+++ b/jsgtk_modules/jsgtk/node_modules.js
@@ -123,7 +123,11 @@
     // Check if we've already loaded this module, if so, throw an error because Babel can't handle
     // circular dependencies.
     if (global.loadedModules.indexOf(module) !== -1) {
-      throw new Error('Circular dependencies detected. Try using the module\'s dist version instead.');
+      if (global.redundantModules > 80) {
+        global.redundantModules = 0;
+        throw new Error('Circular dependencies detected. Try using the module\'s dist version instead.');
+      }
+      ++global.redundantModules;
     }
     let fd = getModuleFile(module, dir);
     if (!fd) {

--- a/jsgtk_modules/jsgtk/node_modules.js
+++ b/jsgtk_modules/jsgtk/node_modules.js
@@ -15,6 +15,7 @@
     DIR_SEPARATOR = constants.DIR_SEPARATOR,
     TRANSFORM = constants.TRANSFORM,
     CURRENT_DIR = constants.CURRENT_DIR,
+    PROGRAM_DIR = constants.PROGRAM_DIR,
 
     modules = Object.create(null),
 
@@ -29,74 +30,106 @@
   function error(module, dir) {
     throw new Error('unable to find module ' + module + ' @ ' + dir);
   }
+  function getPackageJSON (module, dir) {
+    let paths = [dir, CURRENT_DIR, PROGRAM_DIR];
+    let content, packageJSONPath, moduleDirectory;
 
-  function grabModuleFD(path) {
-    let fd = GFile.new_for_path(path);
-    if (fd.query_exists(null)) {
-      switch (fd.query_file_type(Gio.FileQueryInfoFlags.NONE, null)) {
-        case Gio.FileType.REGULAR: return fd;
-        case Gio.FileType.DIRECTORY:
-          fd = GFile.new_for_path(path + DIR_SEPARATOR + 'package.json');
-          if (fd.query_exists(null)) {
-            let content = JSON.parse(String.prototype.trim.call(fd.load_contents(null)[1]));
-            if (content.main == null) content.main = 'index.js';
-            fd = GFile.new_for_path(path + DIR_SEPARATOR + content.main);
-            if (fd.query_exists(null)) return fd;
-          } else {
-            // TODO does npm guarantee a package.json
-            fd = GFile.new_for_path(path + DIR_SEPARATOR + 'main.js');
-            if (fd.query_exists(null)) return fd;
-          }
+    // Get the global node modules path
+    if (process.env.NODE_PATH) {
+      let path;
+      if (process.env.NODE_PATH.indexOf(':') !== -1) {
+        // NODE_PATH looks like '/usr/lib/nodejs:/usr/lib/node_modules:/usr/share/javascript'
+        let parts = process.env.NODE_PATH.split(':');
+        path = parts.filter((part) => {
+          return part.indexOf('node_modules') !== -1;
+        });
+      } else {
+        path = [process.env.NODE_PATH]
       }
-    } else {
-        // cases such as require('my-lib/src/component')
-        let fd = GFile.new_for_path(path + '.js');
-        if (fd.query_exists(null)) return fd;
+      paths.push(path[0]);
     }
-    return null;
+
+    // Iterate our paths starting with local ones first in order to build the absolute path
+    // to this module's directory and package.json file.
+    // TODO: Global modules are not flattened like local node modules, and we may need to
+    // recurse the global node_modules directory as a last resort.
+    for (let i = 0, len = paths.length; i < len; i++) {
+      if (paths[i].indexOf('node_modules') === -1) {
+        paths[i] = paths[i] + DIR_SEPARATOR + 'node_modules';
+      }
+      moduleDirectory = paths[i] + DIR_SEPARATOR + module;
+      packageJSONPath = moduleDirectory + DIR_SEPARATOR + 'package.json';
+
+      let packageJSONFile = GFile.new_for_path(paths[i] + DIR_SEPARATOR + module + DIR_SEPARATOR + 'package.json');
+      if (packageJSONFile.query_exists(null)) {
+        try {
+          content = JSON.parse(String.prototype.trim.call(packageJSONFile.load_contents(null)[1]));
+          break;
+        } catch (e) {}
+      }
+    }
+
+    if (content) {
+      return {
+        content: content,
+        moduleDirectory: moduleDirectory
+      };
+    }
+    return error(module, dir);
   }
 
-  function getModuleFile(path, dir) {
+  function getModuleFile(module, dir) {
     let fd;
-    switch (true) {
-      case GLib.path_is_absolute(path):
-        fd = grabModuleFD(path);
-        if (fd) {
-          return fd;
-        } else if (path.slice(-3) !== '.js') {
-          fd = GFile.new_for_path(path + '.js');
-          if (fd.query_exists(null)) return fd;
-        }
-        return error(path, dir);
-      case '.' === path[0]:
-        return getModuleFile(dir + DIR_SEPARATOR + path);
-      default:
-        const gPs = [dir].concat(require('module').globalPaths);
-        while (gPs.length) {
-          let tmp = GFile.new_for_path(gPs.shift());
-          do {
-            fd = grabModuleFD([
-              tmp.get_path(), 'node_modules', path
-            ].join(DIR_SEPARATOR));
-            if (fd) return fd;
-          } while((tmp = tmp.get_parent()));
-        }
-        // This is a fix for cases when a node module requires one of its dependencies from a child directory
-        if (path.indexOf('.') === -1 && path.indexOf(DIR_SEPARATOR) === -1 && path.indexOf('index') === -1) {
-          let newPath = [
-            CURRENT_DIR, 'node_modules', path, 'index'
-          ].join(DIR_SEPARATOR);
-          return getModuleFile(newPath, dir);
-        }
-        return error(path, dir);
+    // Convert relative paths
+    if (module.slice(0, 3) === '..' + DIR_SEPARATOR) {
+      module = '.' + DIR_SEPARATOR + module;
+    }
+    if (module.slice(0, 2) === '.' + DIR_SEPARATOR) {
+      module = dir + DIR_SEPARATOR + module.slice(2);
+    }
+    if (GLib.path_is_absolute(module)) {
+      if (module.slice(-3) === '.js' || module.slice(-5) === '.json') {
+        fd = GFile.new_for_path(module);
+      } else {
+        fd = GFile.new_for_path(module + '.js');
+      }
+      if (fd.query_exists(null)) {
+        return fd;
+      } else {
+        fd = GFile.new_for_path(module + DIR_SEPARATOR + 'index.js');
+        if (fd.query_exists(null)) return fd;
+      }
+    } else {
+      // Retrieve the package.json file first
+      let moduleInfo = getPackageJSON(module, dir);
+      let packageJSON = moduleInfo.content;
+      // Store the module directory to create the entry file's absolute path
+      let moduleDirectory = moduleInfo.moduleDirectory;
+
+      let mainFile = packageJSON.main ? packageJSON.main : 'index.js';
+
+      if (mainFile.slice(-3) !== '.js') {
+        mainFile = mainFile + '.js';
+      }
+
+      let requiredModule = moduleDirectory  + DIR_SEPARATOR + mainFile;
+      fd = GFile.new_for_path(requiredModule);
+      if (fd.query_exists(null)) return fd;
+      return error(module, dir);
     }
   }
 
   function load(module, dir) {
-    let
-      fd = getModuleFile(module, dir),
-      id = fd.get_path()
-    ;
+    // Check if we've already loaded this module, if so, throw an error because Babel can't handle
+    // circular dependencies.
+    if (global.loadedModules.indexOf(module) !== -1) {
+      throw new Error('Circular dependencies detected. Try using the module\'s dist version instead.');
+    }
+    let fd = getModuleFile(module, dir);
+    if (!fd) {
+      error(module, dir);
+    }
+    let id = fd.get_path();
     // Add ability to require JSON files as objects
     if (id.slice(-5) === '.json') {
       let [success, json] = fd.load_contents(null);
@@ -109,6 +142,7 @@
         error(module, dir);
       }
     } else {
+      global.loadedModules.push(module);
       return evaluate(TRANSFORM, modules, id, id, fd);
     }
   }

--- a/jsgtk_modules/jsgtk/node_modules.js
+++ b/jsgtk_modules/jsgtk/node_modules.js
@@ -44,7 +44,7 @@
           return part.indexOf('node_modules') !== -1;
         });
       } else {
-        path = [process.env.NODE_PATH]
+        path = [process.env.NODE_PATH];
       }
       paths.push(path[0]);
     }

--- a/jsgtk_modules/zlib.js
+++ b/jsgtk_modules/zlib.js
@@ -1,0 +1,3 @@
+module.exports = {
+  createUnzip: ()=>true
+}

--- a/jsgtk_modules/zlib.js
+++ b/jsgtk_modules/zlib.js
@@ -2,4 +2,4 @@ module.exports = {
   createUnzip: function () {
     return true;
   }
-}
+};

--- a/jsgtk_modules/zlib.js
+++ b/jsgtk_modules/zlib.js
@@ -1,3 +1,5 @@
 module.exports = {
-  createUnzip: ()=>true
+  createUnzip: function () {
+    return true;
+  }
 }


### PR DESCRIPTION
I ran into several issues when trying to require mathjs. After I rewrote the module loader so all of its dependencies could be found (and ran your tests and checked other libraries I've previously tried for regressions), I realized its just loading the modules endlessly. I went ahead and added a global that caches the module strings as passed to the load function in node_modules.js, and used that to check if there are circular dependencies. If so, an error is thrown.

There is a Babel plugin that might help: https://github.com/whitecolor/babel-plugin-cycle-circular

It would need to be compiled into a stand alone build so we could integrate it.

Other changes:
- Added a placeholder polyfill for a specific method that's used in the zlib (native) node module that Axios uses. Forgot I commented out its require during testing yesterday.